### PR TITLE
2 roll back version on build failure

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,9 @@ dependencies {
 
     // This dependency is used by the application.
     implementation 'com.google.guava:guava:30.1.1-jre'
+
+    // https://mvnrepository.com/artifact/org.assertj/assertj-core
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
 }
 
 application {

--- a/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/SemanticVersionManager.java
+++ b/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/SemanticVersionManager.java
@@ -2,8 +2,13 @@ package io.github.mainmethod0126.gradle.simple.versioning;
 
 import java.io.IOException;
 
+import org.gradle.BuildListener;
+import org.gradle.BuildResult;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.invocation.Gradle;
+
 import io.github.mainmethod0126.gradle.simple.versioning.task.BuildAndVersioning;
 
 public class SemanticVersionManager implements Plugin<Project> {
@@ -41,35 +46,35 @@ public class SemanticVersionManager implements Plugin<Project> {
                         throw new IllegalStateException(e);
                 }
 
-                // project.getGradle().buildFinished(result -> {
-                // if (result.getFailure() == null) {
-                // System.out.println("build success!!!");
-                // } else {
-                // System.out.println("build fail!!!");
-                // }
-                // });
+                project.getGradle().addBuildListener(new BuildListener() {
 
-                // project.getGradle().buildFinished(new Action<BuildResult>() {
+                        @Override
+                        public void buildFinished(BuildResult buildResult) {
+                                if (buildResult.getFailure() == null) {
 
-                // @Override
-                // public void execute(BuildResult result) {
-                // if (result.getFailure() == null) {
-                // System.out.println("build success!!!");
-                // } else {
-                // System.out.println("build fail!!!");
-                // }
-                // }
-                // });
+                                        System.out.println("------------build Succeed------------");
 
-                // project.getGradle().addListener(new Object() {
-                // void buildFinished(BuildResult result) {
-                // if (result.getFailure() == null) {
-                // System.out.println("build success!!!");
-                // } else {
-                // System.out.println("build fail!!!");
-                // }
-                // }
-                // });
+                                        buildAndVersioning.commit();
+                                }
+
+                        }
+
+                        @Override
+                        public void projectsEvaluated(Gradle buildResult) {
+
+                        }
+
+                        @Override
+                        public void projectsLoaded(Gradle buildResult) {
+
+                        }
+
+                        @Override
+                        public void settingsEvaluated(Settings buildResult) {
+
+                        }
+
+                });
 
         }
 

--- a/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/BuildAndVersioning.java
+++ b/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/BuildAndVersioning.java
@@ -388,8 +388,8 @@ public class BuildAndVersioning extends DefaultTask {
         this.semanticVersionFile.commit();
     }
 
-    public boolean isChanged() {
-        return this.semanticVersionFile.isChanged();
+    public boolean changed() {
+        return this.semanticVersionFile.changed();
     }
 
 }

--- a/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/BuildAndVersioning.java
+++ b/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/BuildAndVersioning.java
@@ -78,6 +78,7 @@ public class BuildAndVersioning extends DefaultTask {
         return file;
     }
 
+
     private void printVersionChangeInfo(String versionName, String prev, String next) {
 
         String tempPrev = (prev.isEmpty()) ? "Empty" : prev;
@@ -382,6 +383,10 @@ public class BuildAndVersioning extends DefaultTask {
 
     public void setSemanticVersionFile(SemanticVersionFile semanticVersionFile) {
         this.semanticVersionFile = semanticVersionFile;
+    }
+
+    public void commit() {
+        this.semanticVersionFile.commit();
     }
 
 }

--- a/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/BuildAndVersioning.java
+++ b/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/BuildAndVersioning.java
@@ -78,7 +78,6 @@ public class BuildAndVersioning extends DefaultTask {
         return file;
     }
 
-
     private void printVersionChangeInfo(String versionName, String prev, String next) {
 
         String tempPrev = (prev.isEmpty()) ? "Empty" : prev;
@@ -387,6 +386,10 @@ public class BuildAndVersioning extends DefaultTask {
 
     public void commit() {
         this.semanticVersionFile.commit();
+    }
+
+    public boolean isChanged() {
+        return this.semanticVersionFile.isChanged();
     }
 
 }

--- a/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/version/SemanticVersion.java
+++ b/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/version/SemanticVersion.java
@@ -2,6 +2,7 @@ package io.github.mainmethod0126.gradle.simple.versioning.task.version;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.json.JSONObject;
@@ -129,4 +130,24 @@ public class SemanticVersion {
         this.buildMetadata = buildMetadata;
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        SemanticVersion that = (SemanticVersion) obj;
+        return Objects.equals(major, that.major) &&
+               Objects.equals(minor, that.minor) &&
+               Objects.equals(patch, that.patch) &&
+               Objects.equals(prereleaseVersion, that.prereleaseVersion) &&
+               Objects.equals(buildMetadata, that.buildMetadata);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(major, minor, patch, prereleaseVersion, buildMetadata);
+    }
 }

--- a/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/version/SemanticVersionFile.java
+++ b/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/version/SemanticVersionFile.java
@@ -222,7 +222,7 @@ public class SemanticVersionFile {
         }
     }
 
-    public boolean isChanged() {
+    public boolean changed() {
         return semanticVersion.equals(committedSemanticVersion);
     }
 

--- a/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/version/SemanticVersionFile.java
+++ b/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/version/SemanticVersionFile.java
@@ -121,7 +121,6 @@ public class SemanticVersionFile {
             try {
                 semanticVersion.getMajor().decrease(value);
             } catch (MinimumLimitException e) {
-                // TODO Auto-generated catch block
                 e.printStackTrace();
             }
 
@@ -131,7 +130,6 @@ public class SemanticVersionFile {
             try {
                 semanticVersion.getMinor().decrease(value);
             } catch (MinimumLimitException e) {
-                // TODO Auto-generated catch block
                 e.printStackTrace();
             }
 
@@ -141,7 +139,6 @@ public class SemanticVersionFile {
             try {
                 semanticVersion.getPatch().decrease(value);
             } catch (MinimumLimitException e) {
-                // TODO Auto-generated catch block
                 e.printStackTrace();
             }
 
@@ -221,7 +218,6 @@ public class SemanticVersionFile {
             save(semanticVersion.toJsonObject());
             this.committedSemanticVersion = this.semanticVersion;
         } catch (IOException e) {
-            // TODO Auto-generated catch block
             e.printStackTrace();
         }
     }

--- a/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/version/SemanticVersionFile.java
+++ b/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/version/SemanticVersionFile.java
@@ -12,6 +12,7 @@ import io.github.mainmethod0126.gradle.simple.versioning.exception.MinimumLimitE
 
 public class SemanticVersionFile {
 
+    private SemanticVersion committedSemanticVersion;
     private SemanticVersion semanticVersion;
     private File file;
 
@@ -32,7 +33,7 @@ public class SemanticVersionFile {
             throw new IOException("failed create file : " + this.file.getPath());
         }
 
-        save(semanticVersion.toJsonObject());
+        commit();
     }
 
     private void save(JSONObject version) throws IOException {
@@ -89,38 +90,17 @@ public class SemanticVersionFile {
         public int major() {
             semanticVersion.getMajor().increase(value);
 
-            try {
-                save(semanticVersion.toJsonObject());
-            } catch (IOException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
-
             return semanticVersion.getMajor().get();
         }
 
         public int minor() {
             semanticVersion.getMinor().increase(value);
 
-            try {
-                save(semanticVersion.toJsonObject());
-            } catch (IOException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
-
             return semanticVersion.getMinor().get();
         }
 
         public int patch() {
             semanticVersion.getPatch().increase(value);
-
-            try {
-                save(semanticVersion.toJsonObject());
-            } catch (IOException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
 
             return semanticVersion.getPatch().get();
         }
@@ -145,25 +125,12 @@ public class SemanticVersionFile {
                 e.printStackTrace();
             }
 
-            try {
-                save(semanticVersion.toJsonObject());
-            } catch (IOException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
         }
 
         public void minor() {
             try {
                 semanticVersion.getMinor().decrease(value);
             } catch (MinimumLimitException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
-
-            try {
-                save(semanticVersion.toJsonObject());
-            } catch (IOException e) {
                 // TODO Auto-generated catch block
                 e.printStackTrace();
             }
@@ -178,12 +145,6 @@ public class SemanticVersionFile {
                 e.printStackTrace();
             }
 
-            try {
-                save(semanticVersion.toJsonObject());
-            } catch (IOException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
         }
     }
 
@@ -197,20 +158,12 @@ public class SemanticVersionFile {
 
         public void prereleaseVersion() {
             semanticVersion.setPrereleaseVersion(this.value);
-            try {
-                save(semanticVersion.toJsonObject());
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
+
         }
 
         public void buildMetadata() {
             semanticVersion.setBuildMetadata(this.value);
-            try {
-                save(semanticVersion.toJsonObject());
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
+
         }
     }
 
@@ -236,48 +189,37 @@ public class SemanticVersionFile {
 
     public void setMajor(int version) {
         semanticVersion.getMajor().set(version);
-        try {
-            save(semanticVersion.toJsonObject());
-        } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
+
     }
 
     public void setMinor(int version) {
         semanticVersion.getMinor().set(version);
-        try {
-            save(semanticVersion.toJsonObject());
-        } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
+
     }
 
     public void setPatch(int version) {
         semanticVersion.getPatch().set(version);
-        try {
-            save(semanticVersion.toJsonObject());
-        } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
+
     }
 
     public void setPrereleaseVersion(String version) {
         semanticVersion.setPrereleaseVersion(version);
-        try {
-            save(semanticVersion.toJsonObject());
-        } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
+
     }
 
     public void setBuildMetadata(String version) {
         semanticVersion.setBuildMetadata(version);
+
+    }
+
+    public void rollback() {
+        this.semanticVersion = this.committedSemanticVersion;
+    }
+
+    public void commit() {
         try {
             save(semanticVersion.toJsonObject());
+            this.committedSemanticVersion = this.semanticVersion;
         } catch (IOException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();

--- a/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/version/SemanticVersionFile.java
+++ b/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/task/version/SemanticVersionFile.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 
 import org.json.JSONObject;
 import org.json.JSONTokener;
+
 import io.github.mainmethod0126.gradle.simple.versioning.exception.MinimumLimitException;
 
 public class SemanticVersionFile {
@@ -59,7 +60,6 @@ public class SemanticVersionFile {
     }
 
     public String getFullString() throws IOException {
-        load();
         return semanticVersion.getFullString();
     }
 
@@ -220,6 +220,10 @@ public class SemanticVersionFile {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    public boolean isChanged() {
+        return semanticVersion.equals(committedSemanticVersion);
     }
 
 }

--- a/app/src/test/java/gradle/simple/versioning/SemanticVersionManagerTest.java
+++ b/app/src/test/java/gradle/simple/versioning/SemanticVersionManagerTest.java
@@ -1,5 +1,7 @@
 package gradle.simple.versioning;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.util.UUID;
 
@@ -8,7 +10,6 @@ import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import io.github.mainmethod0126.gradle.simple.versioning.task.BuildAndVersioning;
-
 
 public class SemanticVersionManagerTest {
 
@@ -50,30 +51,29 @@ public class SemanticVersionManagerTest {
         buildAndVersioning.commit();
     }
 
-    // @Test
-    // @DisplayName("When I didn't call commit in buildAndVersioningTask , the version file doesn't change.")
-    // public void buildAndVersioningTask_increase_not_commit_Test() throws IOException {
+    @Test
+    @DisplayName("When I didn't call commit in buildAndVersioningTask , the version file doesn't change.")
+    public void buildAndVersioningTask_increase_not_commit_Test() throws IOException {
 
-    //     // given
-    //     Project project = ProjectBuilder.builder().build();
-    //     project.getPlugins().apply("java");
-    //     BuildAndVersioning buildAndVersioning = project.getTasks().create("BuildAndVersioning",
-    //             BuildAndVersioning.class);
+        // given
+        Project project = ProjectBuilder.builder().build();
+        project.getPlugins().apply("java");
+        BuildAndVersioning buildAndVersioning = project.getTasks().create("BuildAndVersioning",
+                BuildAndVersioning.class);
 
-    //     buildAndVersioning.setMajor("++");
-    //     buildAndVersioning.setMinor("++");
-    //     buildAndVersioning.setPatch("++");
-    //     buildAndVersioning.setPr("beta" + UUID.randomUUID().toString());
-    //     buildAndVersioning.setBm("test" + UUID.randomUUID().toString());
+        buildAndVersioning.setMajor("++");
+        buildAndVersioning.setMinor("++");
+        buildAndVersioning.setPatch("++");
+        buildAndVersioning.setPr("beta" + UUID.randomUUID().toString());
+        buildAndVersioning.setBm("test" + UUID.randomUUID().toString());
 
-    //     // when
-    //     buildAndVersioning.setProject(project);
+        // when
+        buildAndVersioning.setProject(project);
+        buildAndVersioning.doExcute();
+        buildAndVersioning.commit();
 
-    //     buildAndVersioning.doExcute();
-
-    //     // then
-    //     buildAndVersioning.commit();
-
-    // }
+        // then
+        assertTrue(buildAndVersioning.isChanged());
+    }
 
 }

--- a/app/src/test/java/gradle/simple/versioning/SemanticVersionManagerTest.java
+++ b/app/src/test/java/gradle/simple/versioning/SemanticVersionManagerTest.java
@@ -45,6 +45,9 @@ public class SemanticVersionManagerTest {
         // when, then
         buildAndVersioning.setProject(project);
         buildAndVersioning.doExcute();
+
+        buildAndVersioning.commit();
+
     }
 
 }

--- a/app/src/test/java/gradle/simple/versioning/SemanticVersionManagerTest.java
+++ b/app/src/test/java/gradle/simple/versioning/SemanticVersionManagerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import io.github.mainmethod0126.gradle.simple.versioning.task.BuildAndVersioning;
 
+
 public class SemanticVersionManagerTest {
 
     @Test
@@ -47,7 +48,32 @@ public class SemanticVersionManagerTest {
         buildAndVersioning.doExcute();
 
         buildAndVersioning.commit();
-
     }
+
+    // @Test
+    // @DisplayName("When I didn't call commit in buildAndVersioningTask , the version file doesn't change.")
+    // public void buildAndVersioningTask_increase_not_commit_Test() throws IOException {
+
+    //     // given
+    //     Project project = ProjectBuilder.builder().build();
+    //     project.getPlugins().apply("java");
+    //     BuildAndVersioning buildAndVersioning = project.getTasks().create("BuildAndVersioning",
+    //             BuildAndVersioning.class);
+
+    //     buildAndVersioning.setMajor("++");
+    //     buildAndVersioning.setMinor("++");
+    //     buildAndVersioning.setPatch("++");
+    //     buildAndVersioning.setPr("beta" + UUID.randomUUID().toString());
+    //     buildAndVersioning.setBm("test" + UUID.randomUUID().toString());
+
+    //     // when
+    //     buildAndVersioning.setProject(project);
+
+    //     buildAndVersioning.doExcute();
+
+    //     // then
+    //     buildAndVersioning.commit();
+
+    // }
 
 }

--- a/app/src/test/java/gradle/simple/versioning/SemanticVersionManagerTest.java
+++ b/app/src/test/java/gradle/simple/versioning/SemanticVersionManagerTest.java
@@ -1,5 +1,6 @@
 package gradle.simple.versioning;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -29,8 +30,8 @@ public class SemanticVersionManagerTest {
     }
 
     @Test
-    @DisplayName("buildAndVersioningTask 가 정상적으로 실행되는지 테스트 합니다.")
-    public void buildAndVersioningTask_increaseTest() throws IOException {
+    @DisplayName("If the build succeeds, the incremented version is committed.")
+    public void buildAndVersioningTask_whenBuildSucceed_thenIncreaseCommitTest() throws IOException {
 
         // given
         Project project = ProjectBuilder.builder().build();
@@ -49,11 +50,13 @@ public class SemanticVersionManagerTest {
         buildAndVersioning.doExcute();
 
         buildAndVersioning.commit();
+
+        assertTrue(buildAndVersioning.isChanged());
     }
 
     @Test
-    @DisplayName("When I didn't call commit in buildAndVersioningTask , the version file doesn't change.")
-    public void buildAndVersioningTask_increase_not_commit_Test() throws IOException {
+    @DisplayName("If the build fails, the incremented version is not committed.")
+    public void buildAndVersioningTask_whenBuildFailed_thenNotIncresaseCommitTest() throws IOException {
 
         // given
         Project project = ProjectBuilder.builder().build();
@@ -70,10 +73,9 @@ public class SemanticVersionManagerTest {
         // when
         buildAndVersioning.setProject(project);
         buildAndVersioning.doExcute();
-        buildAndVersioning.commit();
 
         // then
-        assertTrue(buildAndVersioning.isChanged());
+        assertFalse(buildAndVersioning.isChanged());
     }
 
 }

--- a/app/src/test/java/gradle/simple/versioning/SemanticVersionManagerTest.java
+++ b/app/src/test/java/gradle/simple/versioning/SemanticVersionManagerTest.java
@@ -50,7 +50,7 @@ public class SemanticVersionManagerTest {
         buildAndVersioning.doExcute();
         buildAndVersioning.commit();
 
-        assertTrue(buildAndVersioning.isChanged());
+        assertTrue(buildAndVersioning.changed());
     }
 
     @Test
@@ -74,7 +74,7 @@ public class SemanticVersionManagerTest {
         buildAndVersioning.doExcute();
 
         // then
-        assertFalse(buildAndVersioning.isChanged());
+        assertFalse(buildAndVersioning.changed());
     }
 
 }

--- a/demo/app/src/main/java/demo/App.java
+++ b/demo/app/src/main/java/demo/App.java
@@ -11,4 +11,6 @@ public class App {
     public static void main(String[] args) {
         System.out.println(new App().getGreeting());
     }
+
+
 }


### PR DESCRIPTION
Previously, even in the event of a build failure, the version would still increase. However, with the recent update, the version no longer increases in case of a build failure.