### PR TITLE
- I learned that to use Gradle plugin extensions, the properties of t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ replay_pid*
 **/build/
 !src/**/build/
 
+gradle.properties
+
 # Ignore Gradle GUI config
 gradle-app.setting
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,14 +6,14 @@
  * User Manual available at https://docs.gradle.org/7.3/userguide/building_java_projects.html
  */
 
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
-    }
-}
+// buildscript {
+//     repositories {
+//         jcenter()
+//     }
+//     dependencies {
+//         classpath "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
+//     }
+// }
 
 plugins {
     // Apply the application plugin to add support for building a CLI application in Java.
@@ -27,18 +27,17 @@ plugins {
 
 
 
-apply plugin: 'com.github.johnrengelman.shadow'
+// apply plugin: 'com.github.johnrengelman.shadow'
 
 
 group = 'io.github.mainmethod0126'
-version = "0.1.2"
+version = "0.1.4"
 sourceCompatibility = 11
 targetCompatibility = 11
 
 tasks.withType(Javadoc) {
     options.encoding = 'UTF-8'
 }
-
 
 compileJava {
     options.encoding = 'UTF-8'

--- a/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/SemanticVersionManager.java
+++ b/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/SemanticVersionManager.java
@@ -22,7 +22,9 @@ public class SemanticVersionManager implements Plugin<Project> {
 
                 this.project = project;
 
-                initExtensions();
+                project.getExtensions().create("ssv",
+                                SimpleSemanticVersionPluginExtension.class);
+
                 initUtils();
 
                 BuildAndVersioning buildAndVersioning = project.getTasks().create("BuildAndVersioning",
@@ -49,11 +51,14 @@ public class SemanticVersionManager implements Plugin<Project> {
                 buildAndVersioning.setBm(bm);
 
                 buildAndVersioning.setProject(project);
-                try {
-                        buildAndVersioning.doExcute();
-                } catch (IOException e) {
-                        throw new IllegalStateException(e);
-                }
+
+                project.afterEvaluate(pj -> {
+                        try {
+                                buildAndVersioning.doExcute();
+                        } catch (IOException e) {
+                                throw new IllegalStateException(e);
+                        }
+                });
 
                 project.getGradle().addBuildListener(new BuildListener() {
 
@@ -85,10 +90,6 @@ public class SemanticVersionManager implements Plugin<Project> {
 
                 });
 
-        }
-
-        private void initExtensions() {
-                SimpleSemanticVersionPluginExtension.init(this.project);
         }
 
         private void initUtils() {

--- a/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/extension/SimpleSemanticVersionPluginExtension.java
+++ b/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/extension/SimpleSemanticVersionPluginExtension.java
@@ -1,64 +1,8 @@
 package io.github.mainmethod0126.gradle.simple.versioning.extension;
 
-import org.gradle.api.Project;
+import org.gradle.api.provider.Property;
 
-import io.github.mainmethod0126.gradle.simple.versioning.utils.DateUtils;
+public interface SimpleSemanticVersionPluginExtension {
+    Property<Boolean> getIsDateInBuildArtifactDirPath();
 
-/**
- * 
- * I wanted to create it as a singleton object, but it seemed like we would
- * always have to pass the 'project' object as an argument when calling
- * {@code getInstance()} from outside. Therefore, I created the object to be
- * conveniently used after calling the initial {@code initExtension()} function.
- * 
- * warn! : This class was not designed with consideration for multi-threading
- * and is not thread-safe. Please be cautious when using it in a multi-threaded
- * environment.
- */
-public class SimpleSemanticVersionPluginExtension {
-
-    /**
-     * This is not a singleton object, but rather a global variable used for the
-     * convenience of users.
-     */
-    private static SimpleSemanticVersionPluginExtension extension;
-
-    public static void init(Project project) {
-        if (extension == null) {
-            extension = project.getExtensions().create("ssv",
-                    SimpleSemanticVersionPluginExtension.class);
-        }
-    }
-
-    public static SimpleSemanticVersionPluginExtension getExtension() {
-        return extension;
-    }
-
-    private String buildDate = DateUtils.getCurrentDate(DateUtils.DateUnit.DAY);
-    private boolean isDateInBuildArtifactDirPath = false;
-    private String applicationVersion = "0.0.0";
-
-    public boolean isDateInBuildArtifactDirPath() {
-        return isDateInBuildArtifactDirPath;
-    }
-
-    public void setDateInBuildPath(boolean isDateInBuildArtifactDirPath) {
-        this.isDateInBuildArtifactDirPath = isDateInBuildArtifactDirPath;
-    }
-
-    public String getBuildDate() {
-        return buildDate;
-    }
-
-    public void setBuildDate(String buildDate) {
-        this.buildDate = buildDate;
-    }
-
-    public String getApplicationVersion() {
-        return applicationVersion;
-    }
-
-    public void setApplicationVersion(String applicationVersion) {
-        this.applicationVersion = applicationVersion;
-    }
 }

--- a/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/utils/SsvPaths.java
+++ b/app/src/main/java/io/github/mainmethod0126/gradle/simple/versioning/utils/SsvPaths.java
@@ -19,14 +19,22 @@ public class SsvPaths {
         project = pj;
     }
 
-    public static Path getBuildDir() {
-        if (SimpleSemanticVersionPluginExtension.getExtension().isDateInBuildArtifactDirPath()) {
+    public static Path getBuildDir(String buildDate, String applicationVersion) {
+
+        SimpleSemanticVersionPluginExtension extension = (SimpleSemanticVersionPluginExtension) project.getExtensions()
+                .findByName("ssv");
+
+        if (extension == null) {
+            throw new IllegalStateException("Could not find SimpleSemanticVersionPluginExtension");
+        }
+
+        if (extension.getIsDateInBuildArtifactDirPath().getOrElse(false).booleanValue()) {
             return Paths.get(project.getProjectDir().toString(), "dist",
-                    SimpleSemanticVersionPluginExtension.getExtension().getBuildDate(),
-                    SimpleSemanticVersionPluginExtension.getExtension().getApplicationVersion());
+                    buildDate,
+                    applicationVersion);
         } else {
             return Paths.get(project.getProjectDir().toString(), "dist",
-                    SimpleSemanticVersionPluginExtension.getExtension().getApplicationVersion());
+                    applicationVersion);
         }
 
     }

--- a/app/src/test/java/gradle/simple/versioning/SemanticVersionManagerTest.java
+++ b/app/src/test/java/gradle/simple/versioning/SemanticVersionManagerTest.java
@@ -27,7 +27,8 @@ class SemanticVersionManagerTest {
         BuildAndVersioning buildAndVersioning = project.getTasks().create("BuildAndVersioning",
                 BuildAndVersioning.class);
 
-        SimpleSemanticVersionPluginExtension.init(project);
+        project.getExtensions().create("ssv",
+                SimpleSemanticVersionPluginExtension.class);
         SsvPaths.init(project);
 
         // when, then
@@ -45,7 +46,8 @@ class SemanticVersionManagerTest {
         BuildAndVersioning buildAndVersioning = project.getTasks().create("BuildAndVersioning",
                 BuildAndVersioning.class);
 
-        SimpleSemanticVersionPluginExtension.init(project);
+        project.getExtensions().create("ssv",
+                SimpleSemanticVersionPluginExtension.class);
         SsvPaths.init(project);
 
         buildAndVersioning.setMajor("++");
@@ -73,8 +75,9 @@ class SemanticVersionManagerTest {
         BuildAndVersioning buildAndVersioning = project.getTasks().create("BuildAndVersioning",
                 BuildAndVersioning.class);
 
-        SimpleSemanticVersionPluginExtension.init(project);
-        SimpleSemanticVersionPluginExtension.getExtension().setDateInBuildPath(false);
+        SimpleSemanticVersionPluginExtension extension = project.getExtensions().create("ssv",
+                SimpleSemanticVersionPluginExtension.class);
+        extension.getIsDateInBuildArtifactDirPath().set(false);
         SsvPaths.init(project);
 
         buildAndVersioning.setMajor("++");


### PR DESCRIPTION
…he extension must be retrieved from within the action passed to project.afterEvaluate(). If buildAndVersioning.doExcute() is not executed within afterEvaluate, it seems that the properties of the extension cannot be used because the build script is still incomplete.

- Add gradle.properties to the .gitignore file